### PR TITLE
Update egui to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/amPerl/egui-phosphor"
 
 [dependencies]
-egui = { version = "0.21", default-features = false }
+egui = { version = "0.22", default-features = false }


### PR DESCRIPTION
Following yesterday's release of egui 0.22, libraries that depend on it need to have it updated.

Luckily, there weren't any breaking changes.