### PR TITLE
Upgrade egui to v`0.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/amPerl/egui-phosphor"
 
 [dependencies]
-egui = { version = "0.22", default-features = false }
+egui = { version = "0.23", default-features = false }
 
 [features]
 default = ["regular"]
@@ -18,7 +18,7 @@ bold = []
 fill = []
 
 [dev-dependencies]
-eframe = "0.22"
+eframe = "0.23"
 
 [[example]]
 name = "multiple_variants"


### PR DESCRIPTION
Egui just released a new version `0.23`. This PR updates the dependency of both `egui` and `eframe`. I tested both examples and they seem to work fine without any other changes (also looking at the `CHANGELOG.md` I did not find any mention of fonts changes).

It would be great to have a new release of `egui-phosphor` after this PR, but I did not think this PR would be the right place for such a version bump.