### PR TITLE
⬆️ Update egui to `v0.25`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/amPerl/egui-phosphor"
 
 [dependencies]
-egui = { version = "0.24", default-features = false }
+egui = { version = "0.25", default-features = false }
 
 [features]
 default = ["regular"]
@@ -18,7 +18,7 @@ bold = []
 fill = []
 
 [dev-dependencies]
-eframe = "0.24"
+eframe = "0.25"
 
 [[example]]
 name = "multiple_variants"

--- a/examples/multiple_variants.rs
+++ b/examples/multiple_variants.rs
@@ -1,10 +1,11 @@
+use egui::ViewportBuilder;
 use egui_phosphor::{bold, fill, light, regular, thin};
 
 fn main() {
     eframe::run_native(
         "egui-phosphor demo",
         eframe::NativeOptions {
-            initial_window_size: Some(egui::vec2(320.0, 755.0)),
+            viewport: ViewportBuilder::default().with_inner_size((320.0, 755.0)),
             ..Default::default()
         },
         Box::new(|cc| Box::new(Demo::new(cc))),


### PR DESCRIPTION
This updates the `egui` dependency to version 0.25. The only direct change I found was the example's initial window size.