### PR TITLE
fix phosphor fonts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ pub fn add_to_fonts(fonts: &mut egui::FontDefinitions, variant: Variant) {
         .insert("phosphor".into(), variant.font_data());
 
     if let Some(font_keys) = fonts.families.get_mut(&egui::FontFamily::Proportional) {
-        font_keys.insert(0, "phosphor".into());
+        font_keys.push("phosphor".into());
     }
 }


### PR DESCRIPTION
Fixes #27 

You can see an example of the broken font in #29 