### PR TITLE
Fix broken example

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check with all features
+        run: cargo check --workspace --all-targets --features="thin light regular bold fill"

--- a/examples/multiple_variants.rs
+++ b/examples/multiple_variants.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use egui::ViewportBuilder;
 use egui_phosphor::{bold, fill, light, regular, thin};
 
@@ -21,7 +23,7 @@ impl Demo {
 
         fonts.font_data.insert(
             "phosphor-thin".into(),
-            egui_phosphor::Variant::Thin.font_data(),
+            Arc::new(egui_phosphor::Variant::Thin.font_data()),
         );
         fonts.families.insert(
             egui::FontFamily::Name("phosphor-thin".into()),
@@ -30,7 +32,7 @@ impl Demo {
 
         fonts.font_data.insert(
             "phosphor-light".into(),
-            egui_phosphor::Variant::Light.font_data(),
+            Arc::new(egui_phosphor::Variant::Light.font_data()),
         );
         fonts.families.insert(
             egui::FontFamily::Name("phosphor-light".into()),
@@ -39,7 +41,7 @@ impl Demo {
 
         fonts.font_data.insert(
             "phosphor".into(),
-            egui_phosphor::Variant::Regular.font_data(),
+            Arc::new(egui_phosphor::Variant::Regular.font_data()),
         );
         fonts.families.insert(
             egui::FontFamily::Name("phosphor".into()),
@@ -48,7 +50,7 @@ impl Demo {
 
         fonts.font_data.insert(
             "phosphor-bold".into(),
-            egui_phosphor::Variant::Bold.font_data(),
+            Arc::new(egui_phosphor::Variant::Bold.font_data()),
         );
         fonts.families.insert(
             egui::FontFamily::Name("phosphor-bold".into()),
@@ -57,7 +59,7 @@ impl Demo {
 
         fonts.font_data.insert(
             "phosphor-fill".into(),
-            egui_phosphor::Variant::Fill.font_data(),
+            Arc::new(egui_phosphor::Variant::Fill.font_data()),
         );
         fonts.families.insert(
             egui::FontFamily::Name("phosphor-fill".into()),


### PR DESCRIPTION
I noticed that `multiple_variants` wasn't updated to include the `Arc`s for `FontData` now required by `font_data`, so this PR fixes that.

To help with finding this in future, I've also taken the liberty of adding a CI workflow to run `cargo check` across all targets; feel free to remove that from the PR/ask me to do so if that's not desired!