### PR TITLE
build(deps): Bump `egui` to `v0.35`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/amPerl/egui-phosphor"
 
 [dependencies]
-egui = { version = "0.34", default-features = false }
+egui = { version = "0.35", default-features = false }
 
 [features]
 default = ["regular"]
@@ -18,7 +18,7 @@ bold = []
 fill = []
 
 [dev-dependencies]
-eframe = "0.34"
+eframe = "0.35"
 
 [[example]]
 name = "multiple_variants"


### PR DESCRIPTION
Bumps `egui` (and `eframe` in the `dev-dependencies` section) to `v0.35`.