### PR TITLE
ci: Dependabot + auto-merge for egui/eframe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: egui
+      - dependency-name: eframe

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for egui/eframe
+        if: steps.meta.outputs.dependency-names == 'egui' || steps.meta.outputs.dependency-names == 'eframe'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#45.

Adds:
- `.github/dependabot.yml` — weekly cargo updates, `egui` and `eframe` only
- `.github/workflows/dependabot-auto-merge.yml` — auto-merge those Dependabot PRs

Recommended settings after merge:
1. Actions → General → allow GitHub Actions to create and approve pull requests
2. Require the `Check` status so auto-merge waits for CI